### PR TITLE
Remove pepper from API key hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ TIME                  KIND  REMOTE            SUMMARY
 | --dns-port | OASTRIX_DNS_PORT | 53 | DNS server port |
 | --public-ip | OASTRIX_PUBLIC_IP | - | Public IP address of the server (see below) |
 | --db | OASTRIX_DB | oastrix.db | SQLite database path |
-| --pepper | OASTRIX_PEPPER | (auto) | HMAC pepper for API keys |
 
 ### TLS Flags
 
@@ -196,4 +195,3 @@ sudo setcap cap_net_bind_service=+ep ./oastrix
 
 - API keys are shown only once at creation - store securely
 - The database contains captured request data and TLS private keys - secure file permissions (0600)
-- Use `--pepper` or `OASTRIX_PEPPER` for consistent API key hashing across restarts

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -6,9 +6,7 @@ import (
 )
 
 func TestGenerateAPIKey(t *testing.T) {
-	pepper := []byte("test-pepper")
-
-	displayKey, prefix, hash, err := GenerateAPIKey(pepper)
+	displayKey, prefix, hash, err := GenerateAPIKey()
 	if err != nil {
 		t.Fatalf("GenerateAPIKey failed: %v", err)
 	}
@@ -47,46 +45,38 @@ func TestGenerateAPIKey(t *testing.T) {
 }
 
 func TestHashSecretDeterministic(t *testing.T) {
-	pepper := []byte("test-pepper")
 	secret := "test-secret-value"
 
-	hash1 := HashSecret(secret, pepper)
-	hash2 := HashSecret(secret, pepper)
+	hash1 := HashSecret(secret)
+	hash2 := HashSecret(secret)
 
 	if string(hash1) != string(hash2) {
 		t.Error("HashSecret is not deterministic")
 	}
 
-	differentPepper := []byte("different-pepper")
-	hash3 := HashSecret(secret, differentPepper)
+	differentSecret := "different-secret"
+	hash3 := HashSecret(differentSecret)
 	if string(hash1) == string(hash3) {
-		t.Error("HashSecret should produce different results with different pepper")
+		t.Error("HashSecret should produce different results with different secret")
 	}
 }
 
 func TestVerifyAPIKey(t *testing.T) {
-	pepper := []byte("test-pepper")
-
-	displayKey, _, hash, err := GenerateAPIKey(pepper)
+	displayKey, _, hash, err := GenerateAPIKey()
 	if err != nil {
 		t.Fatalf("GenerateAPIKey failed: %v", err)
 	}
 
-	if !VerifyAPIKey(displayKey, hash, pepper) {
+	if !VerifyAPIKey(displayKey, hash) {
 		t.Error("VerifyAPIKey should return true for valid key")
 	}
 
-	if VerifyAPIKey("oastrix_invalid12345_key", hash, pepper) {
+	if VerifyAPIKey("oastrix_invalid12345_key", hash) {
 		t.Error("VerifyAPIKey should return false for invalid key")
 	}
 
-	wrongPepper := []byte("wrong-pepper")
-	if VerifyAPIKey(displayKey, hash, wrongPepper) {
-		t.Error("VerifyAPIKey should return false with wrong pepper")
-	}
-
 	wrongHash := make([]byte, 32)
-	if VerifyAPIKey(displayKey, wrongHash, pepper) {
+	if VerifyAPIKey(displayKey, wrongHash) {
 		t.Error("VerifyAPIKey should return false with wrong hash")
 	}
 }

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -31,7 +31,6 @@ func getAPIKeyID(r *http.Request) int64 {
 type APIServer struct {
 	DB       *sql.DB
 	Domain   string
-	Pepper   []byte
 	Logger   *zap.Logger
 	PublicIP string
 }
@@ -68,7 +67,7 @@ func (s *APIServer) AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if !auth.VerifyAPIKey(apiKey, storedKey.KeyHash, s.Pepper) {
+		if !auth.VerifyAPIKey(apiKey, storedKey.KeyHash) {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			return
 		}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -27,9 +27,7 @@ func setupTestAPIServer(t *testing.T) (*APIServer, string, func()) {
 		t.Fatalf("open database: %v", err)
 	}
 
-	pepper := []byte("test-pepper-12345")
-
-	displayKey, prefix, hash, err := auth.GenerateAPIKey(pepper)
+	displayKey, prefix, hash, err := auth.GenerateAPIKey()
 	if err != nil {
 		database.Close()
 		os.Remove(tmpFile.Name())
@@ -46,7 +44,6 @@ func setupTestAPIServer(t *testing.T) (*APIServer, string, func()) {
 	srv := &APIServer{
 		DB:     database,
 		Domain: "oastrix.example.com",
-		Pepper: pepper,
 	}
 
 	cleanup := func() {
@@ -287,7 +284,7 @@ func TestTokenOwnership_CannotAccessOtherKeysToken(t *testing.T) {
 	tokenValue := createResp.Token
 
 	// Create a second API key
-	displayKey2, prefix2, hash2, err := auth.GenerateAPIKey(srv.Pepper)
+	displayKey2, prefix2, hash2, err := auth.GenerateAPIKey()
 	if err != nil {
 		t.Fatalf("generate second API key: %v", err)
 	}


### PR DESCRIPTION
API keys have ~190 bits of entropy from 32 random bytes, making pepper unnecessary for dictionary attack protection. Simplifies the design by removing:

- --pepper flag and OASTRIX_PEPPER env var
- Pepper persistence problem (random pepper on restart broke keys)
- HMAC in favor of plain SHA-256 hash

The high-entropy random secret provides equivalent security.