### PR TITLE
Remove redundant TOCTOU check in token creation

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -146,16 +146,6 @@ func (s *APIServer) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	existing, err := db.GetTokenByValue(s.DB, tok)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "database error"})
-		return
-	}
-	if existing != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "token collision, please retry"})
-		return
-	}
-
 	var labelPtr *string
 	if req.Label != "" {
 		labelPtr = &req.Label


### PR DESCRIPTION
The check for existing tokens before insert is unnecessary since the UNIQUE constraint on the tokens table handles collisions.