### PR TITLE
refactor: extract shared API types to internal/api package

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,66 @@
+package api
+
+type CreateTokenRequest struct {
+	Label string `json:"label,omitempty"`
+}
+
+type CreateTokenResponse struct {
+	Token    string            `json:"token"`
+	Payloads map[string]string `json:"payloads"`
+}
+
+type TokenInfo struct {
+	Token            string  `json:"token"`
+	Label            *string `json:"label"`
+	CreatedAt        string  `json:"created_at"`
+	InteractionCount int     `json:"interaction_count"`
+}
+
+type ListTokensResponse struct {
+	Tokens []TokenInfo `json:"tokens"`
+}
+
+type InteractionResponse struct {
+	ID         int64                  `json:"id"`
+	Kind       string                 `json:"kind"`
+	OccurredAt string                 `json:"occurred_at"`
+	RemoteIP   string                 `json:"remote_ip"`
+	RemotePort int                    `json:"remote_port"`
+	TLS        bool                   `json:"tls"`
+	Summary    string                 `json:"summary"`
+	HTTP       *HTTPInteractionDetail `json:"http,omitempty"`
+	DNS        *DNSInteractionDetail  `json:"dns,omitempty"`
+}
+
+type HTTPInteractionDetail struct {
+	Method  string              `json:"method"`
+	Scheme  string              `json:"scheme"`
+	Host    string              `json:"host"`
+	Path    string              `json:"path"`
+	Query   string              `json:"query"`
+	Headers map[string][]string `json:"headers"`
+	Body    string              `json:"body"`
+}
+
+type DNSInteractionDetail struct {
+	QName    string `json:"qname"`
+	QType    int    `json:"qtype"`
+	QClass   int    `json:"qclass"`
+	RD       bool   `json:"rd"`
+	Opcode   int    `json:"opcode"`
+	DNSID    int    `json:"dns_id"`
+	Protocol string `json:"protocol"`
+}
+
+type GetInteractionsResponse struct {
+	Token        string                `json:"token"`
+	Interactions []InteractionResponse `json:"interactions"`
+}
+
+type DeleteTokenResponse struct {
+	Deleted bool `json:"deleted"`
+}
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rsclarke/oastrix/internal/api"
 	"github.com/rsclarke/oastrix/internal/auth"
 	"github.com/rsclarke/oastrix/internal/db"
 )
@@ -138,7 +139,7 @@ func TestCreateToken(t *testing.T) {
 		t.Errorf("expected status 200, got %d", w.Code)
 	}
 
-	var resp createTokenResponse
+	var resp api.CreateTokenResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestGetInteractions(t *testing.T) {
 	createW := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(createW, createReq)
 
-	var createResp createTokenResponse
+	var createResp api.CreateTokenResponse
 	json.NewDecoder(createW.Body).Decode(&createResp)
 
 	req := httptest.NewRequest("GET", "/v1/tokens/"+createResp.Token+"/interactions", nil)
@@ -180,7 +181,7 @@ func TestGetInteractions(t *testing.T) {
 		t.Errorf("expected status 200, got %d", w.Code)
 	}
 
-	var resp getInteractionsResponse
+	var resp api.GetInteractionsResponse
 	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
@@ -218,7 +219,7 @@ func TestDeleteToken(t *testing.T) {
 	createW := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(createW, createReq)
 
-	var createResp createTokenResponse
+	var createResp api.CreateTokenResponse
 	json.NewDecoder(createW.Body).Decode(&createResp)
 
 	req := httptest.NewRequest("DELETE", "/v1/tokens/"+createResp.Token, nil)
@@ -279,7 +280,7 @@ func TestTokenOwnership_CannotAccessOtherKeysToken(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", createW.Code)
 	}
 
-	var createResp createTokenResponse
+	var createResp api.CreateTokenResponse
 	json.NewDecoder(createW.Body).Decode(&createResp)
 	tokenValue := createResp.Token
 


### PR DESCRIPTION
Move duplicated request/response types from internal/server and internal/client into a shared internal/api/types.go package.

Both server and client now import from the shared package, reducing duplication and ensuring consistency between API representations.

Closes #20