### PR TITLE
docs: add conventional commits guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ Full reference: [docs/go-style-guide.md](docs/go-style-guide.md)
 - Goroutines must be stoppable via context cancellation
 - Prefer `any` over `interface{}`
 
+## Commits
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) when writing commit messages.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
Adds Conventional Commits specification to AGENTS.md to guide commit message formatting.