### PR TITLE
fix: remove dead code in parseVersion validation

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -102,10 +102,14 @@ func applyMigrations(db *sql.DB) error {
 
 func parseVersion(filename string) (int, error) {
 	parts := strings.SplitN(filename, "_", 2)
-	if len(parts) == 0 {
+	if len(parts) < 2 || parts[0] == "" {
 		return 0, fmt.Errorf("invalid migration filename: %s", filename)
 	}
-	return strconv.Atoi(parts[0])
+	version, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, fmt.Errorf("parse version number from %q: %w", filename, err)
+	}
+	return version, nil
 }
 
 // TokenWithCount represents a token along with its interaction count.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -101,3 +101,32 @@ func TestCascadeDelete(t *testing.T) {
 		t.Errorf("expected 0 interactions after cascade delete, got %d", count)
 	}
 }
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     int
+		wantErr  bool
+	}{
+		{"valid", "001_create_tables.sql", 1, false},
+		{"valid large", "123_add_column.sql", 123, false},
+		{"missing underscore", "001.sql", 0, true},
+		{"empty prefix", "_create_tables.sql", 0, true},
+		{"non-numeric prefix", "abc_create_tables.sql", 0, true},
+		{"empty string", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVersion(tt.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseVersion(%q) error = %v, wantErr %v", tt.filename, err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseVersion(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the dead code path in `parseVersion` that could never execute.

## Changes

- Replace impossible `len(parts) == 0` check with `len(parts) < 2` (missing underscore separator)
- Add empty prefix validation (`parts[0] == ""`)
- Wrap `strconv.Atoi` error with filename context for debugging
- Add comprehensive unit tests for `parseVersion`

## Test Cases Added

| Input | Expected |
|-------|----------|
| `001_create_tables.sql` | 1, no error |
| `123_add_column.sql` | 123, no error |
| `001.sql` | error (missing underscore) |
| `_create_tables.sql` | error (empty prefix) |
| `abc_create_tables.sql` | error (non-numeric) |
| `""` | error (empty string) |

Closes #32