### PR TITLE
chore: modernize interface{} to any alias

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -306,7 +306,7 @@ func (s *APIServer) handleDeleteToken(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, api.DeleteTokenResponse{Deleted: true})
 }
 
-func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+func writeJSON(w http.ResponseWriter, status int, data any) {
 	buf := new(bytes.Buffer)
 	if err := json.NewEncoder(buf).Encode(data); err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Updates the `writeJSON` function signature in `internal/server/api.go` to use the modern `any` alias instead of `interface{}`.

Go 1.18 introduced `any` as a built-in alias for `interface{}`. Using `any` is the idiomatic style and improves readability.

## Changes

- Replaced `interface{}` with `any` in `writeJSON` signature

Closes #34