### PR TITLE
chore: add CI workflow with SHA-pinned actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          args: --timeout=5m
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test


### PR DESCRIPTION
Add GitHub Actions CI workflow that runs on push/PR to main:

- Checkout repository
- Set up Go from go.mod
- Run golangci-lint
- Build with `make build`
- Test with `make test`

All actions are SHA-pinned for security:
- `actions/checkout@v6.0.1`
- `actions/setup-go@v6.2.0`
- `golangci/golangci-lint-action@v9.2.0`